### PR TITLE
fix: custom dictionary support for `roblox` keywords

### DIFF
--- a/src/configs/spelling.ts
+++ b/src/configs/spelling.ts
@@ -1,3 +1,5 @@
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
 import { GLOB_SRC } from "src";
 import { pluginCspell } from "src/plugins";
 
@@ -8,6 +10,8 @@ import type {
 	TypedFlatConfigItem,
 } from "../types";
 
+const require = createRequire(import.meta.url);
+
 export async function spelling(
 	options: OptionsComponentExtensions & OptionsFiles & SpellCheckConfig = {},
 ): Promise<Array<TypedFlatConfigItem>> {
@@ -17,6 +21,10 @@ export async function spelling(
 		GLOB_SRC,
 		...componentExtensions.map(extension => `**/*.${extension}`),
 	];
+
+	const robloxPackage = require.resolve("@isentinel/dict-roblox");
+	const urlRobloxPackage = pathToFileURL(robloxPackage);
+	const urlRoblox = new URL("dict/roblox.txt", urlRobloxPackage);
 
 	return [
 		{
@@ -32,10 +40,17 @@ export async function spelling(
 						autoFix: false,
 						checkComments: true,
 						cspell: {
-							import: ["@isentinel/dict-roblox"],
+							dictionaries: ["roblox"],
+							dictionaryDefinitions: [
+								{
+									name: "roblox",
+									path: urlRoblox.href,
+								},
+							],
 							language,
 							words: ["isentinel"],
 						},
+						// debugMode: true,
 						generateSuggestions: true,
 						numSuggestions: 8,
 					},

--- a/src/test/example.test.ts
+++ b/src/test/example.test.ts
@@ -1,0 +1,1 @@
+export const words = ["isentinel", "resetmemorycategory"];

--- a/src/test/example.test.ts
+++ b/src/test/example.test.ts
@@ -1,1 +1,0 @@
-export const words = ["isentinel", "resetmemorycategory"];


### PR DESCRIPTION
@christopher-buss,

This PR is a workaround example for https://github.com/streetsidesoftware/cspell/discussions/5787