### PR TITLE
fix(style/spaced-comment): should ignore hot comments

### DIFF
--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -80,6 +80,7 @@ export async function stylistic(
 					},
 				],
 				"style/quotes": ["error", "double"],
+				"style/spaced-comment": ["error", "always", { markers: ["!native", "!optimize"] }],
 			},
 		},
 	];


### PR DESCRIPTION
Currently it'll "autofix" `//!native` to be `// !native`