### PR TITLE
fix(id-length): should accept `e`

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -150,7 +150,7 @@ export async function typescript(
 				"id-length": [
 					"error",
 					{
-						exceptions: ["_", "x", "y", "z", "a", "b"],
+						exceptions: ["_", "x", "y", "z", "a", "b", "e"],
 						max: 30,
 						min: 2,
 						properties: "never",


### PR DESCRIPTION
Currently `id-length` disallows the idom of `import { createElement as e } from "@rbxts/react"`