### PR TITLE
fix(jsdoc/require-description): allow `see` to not have a description

### DIFF
--- a/src/configs/jsdoc.ts
+++ b/src/configs/jsdoc.ts
@@ -27,7 +27,7 @@ export async function jsdoc(options: OptionsStylistic = {}): Promise<Array<Typed
 				"jsdoc/require-asterisk-prefix": "warn",
 				"jsdoc/require-description": [
 					"warn",
-					{ exemptedBy: ["hidden, ignore", "inheritdoc", "client", "server"] },
+					{ exemptedBy: ["hidden, ignore", "inheritdoc", "client", "server", "see"] },
 				],
 				"jsdoc/require-description-complete-sentence": "warn",
 				"jsdoc/require-hyphen-before-param-description": "warn",


### PR DESCRIPTION
Allows me to have things such as
```ts
/**
 * @see https://discord.com/channels/476080952636997633/476080952636997635/1146857136358432900
 */
```