### PR TITLE
fix(perfectionist/sort-enums): sort numerically when possible

### DIFF
--- a/src/configs/perfectionist.ts
+++ b/src/configs/perfectionist.ts
@@ -59,7 +59,7 @@ export async function perfectionist(
 				],
 				"perfectionist/sort-enums": [
 					"error",
-					{ partitionByComment: "Part:**", type: "natural" },
+					{ forceNumericSort: true, partitionByComment: "Part:**", type: "natural" },
 				],
 				"perfectionist/sort-interfaces": [
 					"error",


### PR DESCRIPTION
If an `enum`/`const enum` has numerical values they should sort in numerical order of the values instead of alphabetical names.

E.g.
```ts
export enum EngineerCertificationLevel {
	NotCertified = 0,
	EN101 = 101,
	EN102 = 102,
	EN103 = 103,
	EN204 = 204,
}
```
instead of
```ts
export enum EngineerCertificationLevel {
	EN101 = 101,
	EN102 = 102,
	EN103 = 103,
	EN204 = 204,
	NotCertified = 0,
}
```

This does not affect enums that do not have numerical values