### PR TITLE
fix(ts/prefer-literal-enum-member): should allow bitwise expressions

### DIFF
--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -268,6 +268,7 @@ export async function typescript(
 				"ts/no-wrapper-object-types": "error",
 				"ts/prefer-for-of": "error",
 				"ts/prefer-function-type": "error",
+				"ts/prefer-literal-enum-member": ["error", { allowBitwiseExpressions: true }],
 				"ts/triple-slash-reference": "off",
 				"ts/unified-signatures": "off",
 				yoda: ["error", "never"],


### PR DESCRIPTION
Currently, `ts/prefer-literal-enum-member` will error with something like
```ts
export const enum Permission {
	Everyone = 1,
	QA = 1 << 1,
	Developer = 1 << 2,
	// BD = 1 << 3,
}
```
This PR rectifies this.