### PR TITLE
fix(unicorn/prevent-abbreviations): regression introduced in #212

### DIFF
--- a/src/configs/unicorn.ts
+++ b/src/configs/unicorn.ts
@@ -61,10 +61,7 @@ export async function unicorn(): Promise<Array<TypedFlatConfigItem>> {
 							dist: {
 								distance: true,
 							},
-							e: {
-								err: true,
-								error: false,
-							},
+							e: false,
 							err: false,
 							fn: {
 								func: true,


### PR DESCRIPTION
Apologies - I realised I made a regression introduced in #212 where it would allow `e` for `React.createElement` and then it would by disallowed by `unicorn/prevent-abbreviations`.