### PR TITLE
fix(prettier): resolve circular import dependency

### DIFF
--- a/src/configs/prettier.ts
+++ b/src/configs/prettier.ts
@@ -1,7 +1,8 @@
 import { createRequire } from "module";
 import type { Options as PrettierOptions } from "prettier";
 
-import { defaultPluginRenaming, GLOB_SRC, interopDefault, renameRules } from "..";
+import { defaultPluginRenaming } from "../factory";
+import { GLOB_SRC } from "../globs";
 import type {
 	OptionsComponentExtensions,
 	OptionsFiles,
@@ -9,6 +10,7 @@ import type {
 	OptionsTypeScriptParserOptions,
 	TypedFlatConfigItem,
 } from "../types";
+import { interopDefault, renameRules } from "../utils";
 
 const require = createRequire(import.meta.url);
 


### PR DESCRIPTION
The prettier config was importing from the root index which caused a circular dependency during ESLint configuration loading. Fixed by importing directly from specific modules (factory, globs, utils) instead of through the index barrel export.