### PR TITLE
feat(package-json): add additional validation rules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,12 +47,44 @@ jobs:
       - name: Typecheck
         run: nr typecheck
 
+  node-compatibility:
+    runs-on: ubuntu-latest
+    name: Node.js compatibility test
+
+    strategy:
+      matrix:
+        node: [22.0.0, 22.x, 24.x]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+
+      - name: Set node ${{ matrix.node }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Setup
+        run: npm i -g @antfu/ni
+
+      - name: Install
+        run: nci
+
+      - name: Build
+        run: nr build
+
+      - name: Lint
+        run: nr lint
+
   build:
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        node: [lts/*]
+        node: [22.0.0, lts/*, current]
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
 

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ src/typegen.d.ts
 
 # cspell
 .cspellcache
+
+# claude
+.claude

--- a/package.json
+++ b/package.json
@@ -137,14 +137,17 @@
 		"@eslint-react/eslint-plugin": {
 			"optional": true
 		},
-		"eslint-plugin-react-roblox-hooks": {
+		"eslint-plugin-jest": {
 			"optional": true
 		},
-		"eslint-plugin-jest": {
+		"eslint-plugin-react-roblox-hooks": {
 			"optional": true
 		}
 	},
 	"packageManager": "pnpm@10.14.0",
+	"engines": {
+		"node": ">=22.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ catalogs:
       specifier: 3.3.0
       version: 3.3.0
     eslint-plugin-package-json:
-      specifier: 0.30.0
-      version: 0.30.0
+      specifier: 0.48.0
+      version: 0.48.0
     eslint-plugin-perfectionist:
       specifier: 4.15.0
       version: 4.15.0
@@ -315,7 +315,7 @@ importers:
         version: 3.3.0
       eslint-plugin-package-json:
         specifier: catalog:prod
-        version: 0.30.0(@types/estree@1.0.8)(eslint@9.32.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.0)
+        version: 0.48.0(@types/estree@1.0.8)(eslint@9.32.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.0)
       eslint-plugin-perfectionist:
         specifier: catalog:prod
         version: 4.15.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
@@ -452,8 +452,8 @@ importers:
 
 packages:
 
-  '@altano/repository-tools@0.1.1':
-    resolution: {integrity: sha512-5vbUs2A98CC3g1AlOBdkBE0BMukkLjLIsMHAtuxg6Pt9dQXxYWdLKOf66v6c/vIqtNcgTMv0oGtddLdMuH9X6w==}
+  '@altano/repository-tools@2.0.1':
+    resolution: {integrity: sha512-YE/52CkFtb+YtHPgbWPai7oo5N9AKnMuP5LM+i2AG7G1H2jdYBCO1iDnkDE3dZ3C1MIgckaF+d5PNRulgt0bdw==}
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -1714,10 +1714,6 @@ packages:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
 
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
@@ -1884,17 +1880,9 @@ packages:
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
-  detect-indent@6.1.0:
-    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
-    engines: {node: '>=8'}
-
   detect-indent@7.0.1:
     resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
     engines: {node: '>=12.20'}
-
-  detect-newline@3.1.0:
-    resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
-    engines: {node: '>=8'}
 
   detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
@@ -2031,9 +2019,9 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-fix-utils@0.2.1:
-    resolution: {integrity: sha512-vHvLGmqdgPhZgH+cymlAlAqVuV22auB+uk/mgFdg5zotEtMHAHcOzNzhr5XOrDzyKGEQY2uQHoT+tS8P36/2CQ==}
-    engines: {node: '>=18.3.0'}
+  eslint-fix-utils@0.4.0:
+    resolution: {integrity: sha512-nCEciwqByGxsKiWqZjqK7xfL+7dUX9Pi0UL3J0tOwfxVN9e6Y59UxEt1ZYsc3XH0ce6T1WQM/QU2DbKK/6IG7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@types/estree': '>=1'
       eslint: '>=8'
@@ -2243,9 +2231,9 @@ packages:
     resolution: {integrity: sha512-brcKcxGnISN2CcVhXJ/kEQlNa0MEfGRtwKtWA16SkqXHKitaKIMrfemJKLKX1YqDU5C/5JY3PvZXd5jEW04e0Q==}
     engines: {node: '>=5.0.0'}
 
-  eslint-plugin-package-json@0.30.0:
-    resolution: {integrity: sha512-kcV3OBEn2252O9SRNtZOyUj7fSGk9nI9WoRyhS46XgFQ07mbK1fDR9YQBGOZzr/rzOuB2PpwIiGAntEHuIHOrg==}
-    engines: {node: '>=18'}
+  eslint-plugin-package-json@0.48.0:
+    resolution: {integrity: sha512-M8Dx4GDhpe9oRvWr84nsrCK+tfLIE5RI+GcyM0wm9KUghmp5mYGL+BO0kzA686dPuEwVTbmfEAazY7tt3hMQtA==}
+    engines: {node: ^=20.19.0 || >=22.12.0}
     peerDependencies:
       eslint: '>=8.0.0'
       jsonc-eslint-parser: ^2.0.0
@@ -3350,9 +3338,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  package-json-validator@0.10.2:
-    resolution: {integrity: sha512-i8qx/xfHdkzOzP39bNOtK6VauRrLdJoQf7L1lVRG2/evpLAd3vrj3EGNlzB9QiztBerxWAx5QXZh5z+Jfi0IvQ==}
-    engines: {node: '>=18'}
+  package-json-validator@0.24.1:
+    resolution: {integrity: sha512-MTtImbS7Cn170JdSe/p2vxtNPtICZhs5P5npHOiDwEspD0F0FrI8krZ1N3t3tHGpMeZrMGSa5sdNH17hJHDwXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   package-manager-detector@1.3.0:
@@ -3569,10 +3557,6 @@ packages:
     resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
     engines: {node: '>=0.10'}
 
-  require-directory@2.1.1:
-    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3736,8 +3720,14 @@ packages:
     engines: {node: '>= 8'}
     deprecated: The work that was done in this beta branch won't be included in future versions
 
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
   spdx-exceptions@2.5.0:
     resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
 
   spdx-expression-parse@4.0.0:
     resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
@@ -4020,6 +4010,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
   validate-npm-package-name@6.0.2:
     resolution: {integrity: sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -4106,17 +4099,9 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
 
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
@@ -4139,7 +4124,7 @@ packages:
 
 snapshots:
 
-  '@altano/repository-tools@0.1.1': {}
+  '@altano/repository-tools@2.0.1': {}
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -5484,12 +5469,6 @@ snapshots:
       slice-ansi: 5.0.0
       string-width: 7.2.0
 
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
   cliui@9.0.1:
     dependencies:
       string-width: 7.2.0
@@ -5677,11 +5656,7 @@ snapshots:
 
   destr@2.0.5: {}
 
-  detect-indent@6.1.0: {}
-
   detect-indent@7.0.1: {}
-
-  detect-newline@3.1.0: {}
 
   detect-newline@4.0.1: {}
 
@@ -5890,7 +5865,7 @@ snapshots:
     dependencies:
       eslint: 9.32.0(jiti@2.5.1)
 
-  eslint-fix-utils@0.2.1(@types/estree@1.0.8)(eslint@9.32.0(jiti@2.5.1)):
+  eslint-fix-utils@0.4.0(@types/estree@1.0.8)(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
       eslint: 9.32.0(jiti@2.5.1)
     optionalDependencies:
@@ -6156,15 +6131,16 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.3.0: {}
 
-  eslint-plugin-package-json@0.30.0(@types/estree@1.0.8)(eslint@9.32.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.0):
+  eslint-plugin-package-json@0.48.0(@types/estree@1.0.8)(eslint@9.32.0(jiti@2.5.1))(jsonc-eslint-parser@2.4.0):
     dependencies:
-      '@altano/repository-tools': 0.1.1
-      detect-indent: 6.1.0
-      detect-newline: 3.1.0
+      '@altano/repository-tools': 2.0.1
+      change-case: 5.4.4
+      detect-indent: 7.0.1
+      detect-newline: 4.0.1
       eslint: 9.32.0(jiti@2.5.1)
-      eslint-fix-utils: 0.2.1(@types/estree@1.0.8)(eslint@9.32.0(jiti@2.5.1))
+      eslint-fix-utils: 0.4.0(@types/estree@1.0.8)(eslint@9.32.0(jiti@2.5.1))
       jsonc-eslint-parser: 2.4.0
-      package-json-validator: 0.10.2
+      package-json-validator: 0.24.1
       semver: 7.7.2
       sort-object-keys: 1.1.3
       sort-package-json: 3.4.0
@@ -7626,9 +7602,11 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  package-json-validator@0.10.2:
+  package-json-validator@0.24.1:
     dependencies:
-      yargs: 17.7.2
+      semver: 7.7.2
+      validate-npm-package-license: 3.0.4
+      yargs: 18.0.0
 
   package-manager-detector@1.3.0: {}
 
@@ -7822,8 +7800,6 @@ snapshots:
       jsesc: 3.0.2
 
   repeat-string@1.6.1: {}
-
-  require-directory@2.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -8026,7 +8002,17 @@ snapshots:
     dependencies:
       whatwg-url: 7.1.0
 
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.21
+
   spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.21
 
   spdx-expression-parse@4.0.0:
     dependencies:
@@ -8387,6 +8373,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+
   validate-npm-package-name@6.0.2: {}
 
   vscode-languageserver-textdocument@1.0.12: {}
@@ -8483,19 +8474,7 @@ snapshots:
 
   yaml@2.8.0: {}
 
-  yargs-parser@21.1.1: {}
-
   yargs-parser@22.0.0: {}
-
-  yargs@17.7.2:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
 
   yargs@18.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,7 +58,7 @@ catalogs:
     eslint-plugin-jsdoc: 52.0.0
     eslint-plugin-jsonc: 2.20.0
     eslint-plugin-no-only-tests: 3.3.0
-    eslint-plugin-package-json: 0.30.0
+    eslint-plugin-package-json: 0.48.0
     eslint-plugin-perfectionist: 4.15.0
     eslint-plugin-pnpm: 0.3.1
     eslint-plugin-promise: 7.2.1

--- a/src/configs/package-json.ts
+++ b/src/configs/package-json.ts
@@ -2,9 +2,9 @@ import type { OptionsProjectType, TypedFlatConfigItem } from "../types";
 import { interopDefault } from "../utils";
 
 export async function packageJson(
-	options: OptionsProjectType = {},
+	options: OptionsProjectType & { roblox?: boolean } = {},
 ): Promise<Array<TypedFlatConfigItem>> {
-	const { type = "game" } = options;
+	const { roblox = true, type = "game" } = options;
 
 	const [jsoncEslintParser, pluginPackageJson] = await Promise.all([
 		interopDefault(import("jsonc-eslint-parser")),
@@ -26,22 +26,37 @@ export async function packageJson(
 				"package-json/no-redundant-files": "error",
 				"package-json/order-properties": "error",
 				"package-json/repository-shorthand": "error",
+				"package-json/require-type": "error",
 				"package-json/sort-collections": "error",
 				"package-json/unique-dependencies": "error",
-				"package-json/valid-local-dependency": "error",
+				"package-json/valid-author": "error",
+				"package-json/valid-bin": "error",
+				"package-json/valid-bundleDependencies": "error",
+				"package-json/valid-config": "error",
+				"package-json/valid-cpu": "error",
+				"package-json/valid-license": "error",
 				"package-json/valid-name": "error",
 				"package-json/valid-package-definition": "error",
 				"package-json/valid-repository-directory": "error",
+				"package-json/valid-scripts": "error",
+				"package-json/valid-type": "error",
 				"package-json/valid-version": "error",
 
 				...(type === "package"
 					? {
 							"package-json/require-author": "error",
+							"package-json/require-description": "error",
 							"package-json/require-files": "error",
 							"package-json/require-keywords": "error",
 							"package-json/require-name": "error",
 							"package-json/require-types": "error",
 							"package-json/require-version": "error",
+						}
+					: {}),
+
+				...(type === "package" && roblox === false
+					? {
+							"package-json/require-engines": "error",
 						}
 					: {}),
 			},

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -141,7 +141,7 @@ export function style(
 		ignores(),
 		imports({ stylistic: stylisticOptions, type: options.type }),
 		jsdoc({ stylistic: stylisticOptions, type: options.type }),
-		packageJson({ type: options.type }),
+		packageJson({ roblox: options.roblox, type: options.type }),
 		promise(),
 		shopify({ stylistic: stylisticOptions }),
 		sonarjs({ isInEditor }),

--- a/src/typegen.d.ts
+++ b/src/typegen.d.ts
@@ -2073,7 +2073,7 @@ export interface RuleOptions {
   /**
    * Reports on unnecessary empty arrays and objects.
    */
-  'package-json/no-empty-fields'?: Linter.RuleEntry<[]>
+  'package-json/no-empty-fields'?: Linter.RuleEntry<PackageJsonNoEmptyFields>
   /**
    * Prevents adding unnecessary / redundant files.
    */
@@ -2091,6 +2091,10 @@ export interface RuleOptions {
    */
   'package-json/require-author'?: Linter.RuleEntry<[]>
   /**
+   * Requires the `description` property to be present.
+   */
+  'package-json/require-description'?: Linter.RuleEntry<[]>
+  /**
    * Requires the `engines` property to be present.
    */
   'package-json/require-engines'?: Linter.RuleEntry<[]>
@@ -2106,6 +2110,10 @@ export interface RuleOptions {
    * Requires the `name` property to be present.
    */
   'package-json/require-name'?: Linter.RuleEntry<[]>
+  /**
+   * Requires the `type` property to be present.
+   */
+  'package-json/require-type'?: Linter.RuleEntry<[]>
   /**
    * Requires the `types` property to be present.
    */
@@ -2127,7 +2135,32 @@ export interface RuleOptions {
    */
   'package-json/unique-dependencies'?: Linter.RuleEntry<[]>
   /**
+   * Enforce that the `author` property is valid.
+   */
+  'package-json/valid-author'?: Linter.RuleEntry<[]>
+  /**
+   * Enforce that the `bin` property is valid.
+   */
+  'package-json/valid-bin'?: Linter.RuleEntry<PackageJsonValidBin>
+  /**
+   * Enforce that the `bundleDependencies` (also: `bundledDependencies`) property is valid.
+   */
+  'package-json/valid-bundleDependencies'?: Linter.RuleEntry<[]>
+  /**
+   * Enforce that the `config` property is valid.
+   */
+  'package-json/valid-config'?: Linter.RuleEntry<[]>
+  /**
+   * Enforce that the `cpu` property is valid.
+   */
+  'package-json/valid-cpu'?: Linter.RuleEntry<[]>
+  /**
+   * Enforce that the `license` property is valid.
+   */
+  'package-json/valid-license'?: Linter.RuleEntry<[]>
+  /**
    * Checks existence of local dependencies in the package.json
+   * @deprecated
    */
   'package-json/valid-local-dependency'?: Linter.RuleEntry<[]>
   /**
@@ -2136,17 +2169,20 @@ export interface RuleOptions {
   'package-json/valid-name'?: Linter.RuleEntry<[]>
   /**
    * Enforce that package.json has all properties required by the npm spec
-   * @deprecated
    */
-  'package-json/valid-package-def'?: Linter.RuleEntry<[]>
-  /**
-   * Enforce that package.json has all properties required by the npm spec
-   */
-  'package-json/valid-package-definition'?: Linter.RuleEntry<[]>
+  'package-json/valid-package-definition'?: Linter.RuleEntry<PackageJsonValidPackageDefinition>
   /**
    * Enforce that if repository directory is specified, it matches the path to the package.json file
    */
   'package-json/valid-repository-directory'?: Linter.RuleEntry<[]>
+  /**
+   * Enforce that the `scripts` property is valid.
+   */
+  'package-json/valid-scripts'?: Linter.RuleEntry<[]>
+  /**
+   * Enforce that the `type` property is valid.
+   */
+  'package-json/valid-type'?: Linter.RuleEntry<[]>
   /**
    * Enforce that package versions are valid semver specifiers
    */
@@ -9184,15 +9220,17 @@ type OperatorLinebreak = []|[("after" | "before" | "none" | null)]|[("after" | "
     [k: string]: ("after" | "before" | "none" | "ignore") | undefined
   }
 }]
+// ----- package-json/no-empty-fields -----
+type PackageJsonNoEmptyFields = []|[{
+  ignoreProperties?: string[]
+}]
 // ----- package-json/order-properties -----
 type PackageJsonOrderProperties = []|[{
   order?: (("legacy" | "sort-package-json") | string[])
-  [k: string]: unknown | undefined
 }]
 // ----- package-json/repository-shorthand -----
 type PackageJsonRepositoryShorthand = []|[{
   form?: ("object" | "shorthand")
-  [k: string]: unknown | undefined
 }]
 // ----- package-json/restrict-dependency-ranges -----
 type PackageJsonRestrictDependencyRanges = []|[({
@@ -9208,6 +9246,14 @@ type PackageJsonRestrictDependencyRanges = []|[({
 }[])]
 // ----- package-json/sort-collections -----
 type PackageJsonSortCollections = []|[string[]]
+// ----- package-json/valid-bin -----
+type PackageJsonValidBin = []|[{
+  enforceCase?: boolean
+}]
+// ----- package-json/valid-package-definition -----
+type PackageJsonValidPackageDefinition = []|[{
+  ignoreProperties?: string[]
+}]
 // ----- padded-blocks -----
 type PaddedBlocks = []|[(("always" | "never") | {
   blocks?: ("always" | "never")


### PR DESCRIPTION
## Summary
- Update eslint-plugin-package-json from 0.30.0 to 0.48.0 (18 versions\!)
- Add comprehensive package.json validation with three-tier rule system
- Update pnpm-workspace-yaml from 0.3.1 to 1.1.0 
- Enable YAML alignMultilineFlowScalars option
- Add Node.js engines requirement with compatibility testing
- Enhance CI with Node.js version matrix testing

## Package.json Rule Structure
**Base Rules (All Projects):**
- All formatting/validation rules + require-type
- All valid-* rules (validate format when fields exist)

**Package Rules (type === "package"):**
- All require-* rules for published packages

**Non-Roblox Package Rules (type === "package" && roblox === false):**
- require-engines for Node.js packages

## Test Plan
- [x] Build and lint pass locally
- [x] Node.js compatibility tested (22.0.0, 22.x, 24.x)
- [x] All new validation rules working correctly
- [ ] CI will test Node.js version matrix